### PR TITLE
Store permission fields

### DIFF
--- a/solr/development-core/conf/solrconfig.xml
+++ b/solr/development-core/conf/solrconfig.xml
@@ -90,12 +90,17 @@
       <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
       <str name="fl">
         id,
-        access_tim,
-        discover_access_group_tim,discover_access_person_tim,
-        read_access_group_tim,read_access_person_tim,
-        edit_access_group_tim,edit_access_person_tim,
+        access_tsim,
+        discover_access_group_tsim,discover_access_person_tsim,
+        read_access_group_tsim,read_access_person_tsim,
+        edit_access_group_tsim,edit_access_person_tsim,
         depositor_ti,
         embargo_release_date_dtsi
+        inheritable_access_tsim,
+        inheritable_discover_access_group_tsim,inheritable_discover_access_person_tsim,
+        inheritable_read_access_group_tsim,inheritable_read_access_person_tsim,
+        inheritable_edit_access_group_tsim,inheritable_edit_access_person_tsim,
+        inheritable_embargo_release_date_dtsi
       </str>
     </lst>
   </requestHandler>

--- a/solr/test-core/conf/solrconfig.xml
+++ b/solr/test-core/conf/solrconfig.xml
@@ -90,12 +90,17 @@
       <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
       <str name="fl">
         id,
-        access_tim,
-        discover_access_group_tim,discover_access_person_tim,
-        read_access_group_tim,read_access_person_tim,
-        edit_access_group_tim,edit_access_person_tim,
+        access_tsim,
+        discover_access_group_tsim,discover_access_person_tsim,
+        read_access_group_tsim,read_access_person_tsim,
+        edit_access_group_tsim,edit_access_person_tsim,
         depositor_ti,
         embargo_release_date_dtsi
+        inheritable_access_tsim,
+        inheritable_discover_access_group_tsim,inheritable_discover_access_person_tsim,
+        inheritable_read_access_group_tsim,inheritable_read_access_person_tsim,
+        inheritable_edit_access_group_tsim,inheritable_edit_access_person_tsim,
+        inheritable_embargo_release_date_dtsi
       </str>
     </lst>
   </requestHandler>


### PR DESCRIPTION
Hydra actually reads these fields, so they need to be stored.
