### PR TITLE
Re-added author, subject and title spellcheckers (copied from blacklight-jetty)

### DIFF
--- a/solr/development-core/conf/solrconfig.xml
+++ b/solr/development-core/conf/solrconfig.xml
@@ -134,6 +134,27 @@
       <str name="spellcheckIndexDir">./spell</str>
       <str name="buildOnOptimize">true</str>
     </lst>
+    <lst name="spellchecker">
+      <str name="name">author</str>
+      <str name="field">author_spell</str>
+      <str name="spellcheckIndexDir">./spell_author</str>
+      <str name="accuracy">0.7</str>
+      <str name="buildOnOptimize">true</str>
+    </lst>
+    <lst name="spellchecker">
+      <str name="name">subject</str>
+      <str name="field">subject_spell</str>
+      <str name="spellcheckIndexDir">./spell_subject</str>
+      <str name="accuracy">0.7</str>
+      <str name="buildOnOptimize">true</str>
+    </lst>
+    <lst name="spellchecker">
+      <str name="name">title</str>
+      <str name="field">title_spell</str>
+      <str name="spellcheckIndexDir">./spell_title</str>
+      <str name="accuracy">0.7</str>
+      <str name="buildOnOptimize">true</str>
+    </lst>
   </searchComponent>
   
   <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" /> 


### PR DESCRIPTION
Blacklight generator adds search fields to catalog controller that expect spellcheckers, e.g.:

```
field.solr_parameters = { :'spellcheck.dictionary' => 'title' }
```

The author, title and subject spellcheckers were previously in the hydra-jetty solrconfig.xml, but were removed for some reason.
