### PR TITLE
Enabling basic authorization for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ When jetty is finished initializing itself, Solr is available at
 and Fedora is available at
 
 * [http://localhost:8983/fedora/](http://localhost:8983/fedora/)
+* basic authorization is enabled an requires the username/password `fedoraAdmin/fedoraAdmin`
+* this is configured under [jetty-users.properties](resources/jetty-users.properties)
 
 You can see a list of all installed applications at
 

--- a/contexts/fedora.xml
+++ b/contexts/fedora.xml
@@ -4,4 +4,14 @@
   <Set name="contextPath">/fedora</Set>
   <Set name="war"><SystemProperty name="jetty.home" default="."/>/webapps/fedora.war</Set>
   <Set name="overrideDescriptor"><SystemProperty name="jetty.home" default="."/>/etc/fedora-override-web.xml</Set>
+  
+  <Get name="securityHandler">
+    <Set name="loginService">
+      <New class="org.eclipse.jetty.security.HashLoginService">
+        <Set name="name">fcrepo4</Set>
+        <Set name="config"><SystemProperty name="jetty.home" default="."/>/resources/jetty-users.properties</Set>
+      </New>
+    </Set>
+  </Get>
+
 </Configure>

--- a/etc/fedora-override-web.xml
+++ b/etc/fedora-override-web.xml
@@ -35,8 +35,6 @@
 
   </servlet-mapping>
 
-  <!--Uncomment section below to enable Basic-Authentication-->
-  <!--
   <security-constraint>
     <web-resource-collection>
       <web-resource-name>Fedora4</web-resource-name>
@@ -62,7 +60,5 @@
     <auth-method>BASIC</auth-method>
     <realm-name>fcrepo</realm-name>
   </login-config>
-  -->
-
 
 </web-app>

--- a/resources/jetty-users.properties
+++ b/resources/jetty-users.properties
@@ -1,0 +1,7 @@
+# Fedora users and passwords. Each line corresponds to:
+#
+# username:  password, role
+#
+# Where role is either fedoraUser or fedoraAdmin as outlined in contexts/fedora.xml
+fedoraUser: fedoraUser,fedoraUser
+fedoraAdmin: fedoraAdmin,fedoraAdmin


### PR DESCRIPTION
ActiveFedora and all Hydra applications pass a username and password in the url for Fedora authorization. This enables that authorization to take place, and if the user wishes, configure it differently. 
